### PR TITLE
Wri changes

### DIFF
--- a/html/header.html
+++ b/html/header.html
@@ -28,6 +28,9 @@
       </h1>
       <nav id="nav-mobile">
         <ul class="mobile-hide">
+          <li>
+            <a href="http://data.globalforestwatch.org/">Home</a>
+          </li>
           <li id="intro-step8">
             <a class="no-link" href="#">Resources</a>
             <ul class="submenu">

--- a/html/header.html
+++ b/html/header.html
@@ -28,9 +28,6 @@
       </h1>
       <nav id="nav-mobile">
         <ul class="mobile-hide">
-          <li>
-            <a href="http://data.globalforestwatch.org/">Home</a>
-          </li>
           <li id="intro-step8">
             <a class="no-link" href="#">Resources</a>
             <ul class="submenu">

--- a/styles/header.css
+++ b/styles/header.css
@@ -3786,6 +3786,24 @@ html {
 ._20398d4dc36e47bd92b559786670f270_1 .download-menu *:not(:last-child) {display:none !important;} /*oil palm*/
 ._8a405466bff2441794628fc5b845fadd_3 .download-menu *:not(:last-child) {display:none !important;} /*managed forests*/
 ._44bbf06379f545daa149ee7b237b9e18_1 .download-menu *:not(:last-child) {display:none !important;} /*Canada forest tenures*/
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts*/
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts*/
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts conf*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts conf*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts conf*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .kml {display:none !important;}  /*land rights*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .zip {display:none !important;}  /*land rights*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .csv {display:none !important;}  /*land rights*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .kml {display:none !important;}  /*oil palm*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .zip {display:none !important;}  /*oil palm*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .csv {display:none !important;}  /*oil palm*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .csv {display:none !important;}  /*managed forests*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .zip {display:none !important;}  /*managed forests*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .kml {display:none !important;}  /*managed forests*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .kml {display:none !important;}  /*wood fiber*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .zip {display:none !important;}  /*wood fiber*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .csv {display:none !important;} /*wood fiber*/
 
 
 .survey-modal {

--- a/styles/header.css
+++ b/styles/header.css
@@ -3786,7 +3786,24 @@ html {
 ._20398d4dc36e47bd92b559786670f270_1 .download-menu *:not(:last-child) {display:none !important;} /*oil palm*/
 ._8a405466bff2441794628fc5b845fadd_3 .download-menu *:not(:last-child) {display:none !important;} /*managed forests*/
 ._44bbf06379f545daa149ee7b237b9e18_1 .download-menu *:not(:last-child) {display:none !important;} /*Canada forest tenures*/
-
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts*/
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts*/
+._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts conf*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts conf*/
+._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts conf*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .kml {display:none !important;}  /*land rights*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .zip {display:none !important;}  /*land rights*/
+._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .csv {display:none !important;}  /*land rights*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .kml {display:none !important;}  /*oil palm*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .zip {display:none !important;}  /*oil palm*/
+._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .csv {display:none !important;}  /*oil palm*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .csv {display:none !important;}  /*managed forests*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .zip {display:none !important;}  /*managed forests*/
+._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .kml {display:none !important;}  /*managed forests*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .kml {display:none !important;}  /*wood fiber*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .zip {display:none !important;}  /*wood fiber*/
+._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .csv {display:none !important;} /*wood fiber*/
 
 .survey-modal {
     position: fixed;

--- a/styles/header.css
+++ b/styles/header.css
@@ -3786,24 +3786,6 @@ html {
 ._20398d4dc36e47bd92b559786670f270_1 .download-menu *:not(:last-child) {display:none !important;} /*oil palm*/
 ._8a405466bff2441794628fc5b845fadd_3 .download-menu *:not(:last-child) {display:none !important;} /*managed forests*/
 ._44bbf06379f545daa149ee7b237b9e18_1 .download-menu *:not(:last-child) {display:none !important;} /*Canada forest tenures*/
-._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts*/
-._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts*/
-._76d3c6a26c9c453595fd86a1de5228df_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts*/
-._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .kml {display:none !important;}  /*GLAD Alerts conf*/
-._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .zip {display:none !important;}  /*GLAD Alerts conf*/
-._96d9920e898d47a5aef6fb4fa5c7dea0_0 .download-menu:last-child .csv {display:none !important;}  /*GLAD Alerts conf*/
-._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .kml {display:none !important;}  /*land rights*/
-._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .zip {display:none !important;}  /*land rights*/
-._e22b22b3525c46f3b35548daf6289903_1 .download-menu:last-child .csv {display:none !important;}  /*land rights*/
-._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .kml {display:none !important;}  /*oil palm*/
-._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .zip {display:none !important;}  /*oil palm*/
-._20398d4dc36e47bd92b559786670f270_1 .download-menu:last-child .csv {display:none !important;}  /*oil palm*/
-._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .csv {display:none !important;}  /*managed forests*/
-._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .zip {display:none !important;}  /*managed forests*/
-._8a405466bff2441794628fc5b845fadd_3 .download-menu:last-child .kml {display:none !important;}  /*managed forests*/
-._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .kml {display:none !important;}  /*wood fiber*/
-._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .zip {display:none !important;}  /*wood fiber*/
-._eca9f0db800a4d5c83bbf7f231c67949_0 .download-menu:last-child .csv {display:none !important;} /*wood fiber*/
 
 
 .survey-modal {


### PR DESCRIPTION
Made some changes to synchronize the vizzuality repo (github.com/vizzuality/gfw_odp) with the wri repo (github.com/wri/odp_front_end). Changes have additional css to hide certain download options for glad alerts, land rights, oil palm, managed forests, and wood fiber layers. As well as adding a "home" button to the header. 